### PR TITLE
Tflite 2.1.0

### DIFF
--- a/TFLite_detection_image.py
+++ b/TFLite_detection_image.py
@@ -60,10 +60,10 @@ if (not IM_NAME and not IM_DIR):
     IM_NAME = 'test1.jpg'
 
 # Import TensorFlow libraries
-# If tensorflow is not installed, import interpreter from tflite_runtime, else import from regular tensorflow
+# If tflite_runtime is installed, import interpreter from tflite_runtime, else import from regular tensorflow
 # If using Coral Edge TPU, import the load_delegate library
-pkg = importlib.util.find_spec('tensorflow')
-if pkg is None:
+pkg = importlib.util.find_spec('tflite_runtime')
+if pkg:
     from tflite_runtime.interpreter import Interpreter
     if use_TPU:
         from tflite_runtime.interpreter import load_delegate

--- a/TFLite_detection_stream.py
+++ b/TFLite_detection_stream.py
@@ -94,10 +94,10 @@ imW, imH = int(resW), int(resH)
 use_TPU = args.edgetpu
 
 # Import TensorFlow libraries
-# If tensorflow is not installed, import interpreter from tflite_runtime, else import from regular tensorflow
+# If tflite_runtime is installed, import interpreter from tflite_runtime, else import from regular tensorflow
 # If using Coral Edge TPU, import the load_delegate library
-pkg = importlib.util.find_spec('tensorflow')
-if pkg is None:
+pkg = importlib.util.find_spec('tflite_runtime')
+if pkg:
     from tflite_runtime.interpreter import Interpreter
     if use_TPU:
         from tflite_runtime.interpreter import load_delegate

--- a/TFLite_detection_video.py
+++ b/TFLite_detection_video.py
@@ -47,10 +47,10 @@ min_conf_threshold = float(args.threshold)
 use_TPU = args.edgetpu
 
 # Import TensorFlow libraries
-# If tensorflow is not installed, import interpreter from tflite_runtime, else import from regular tensorflow
+# If tflite_runtime is installed, import interpreter from tflite_runtime, else import from regular tensorflow
 # If using Coral Edge TPU, import the load_delegate library
-pkg = importlib.util.find_spec('tensorflow')
-if pkg is None:
+pkg = importlib.util.find_spec('tflite_runtime')
+if pkg:
     from tflite_runtime.interpreter import Interpreter
     if use_TPU:
         from tflite_runtime.interpreter import load_delegate

--- a/TFLite_detection_webcam.py
+++ b/TFLite_detection_webcam.py
@@ -91,10 +91,10 @@ imW, imH = int(resW), int(resH)
 use_TPU = args.edgetpu
 
 # Import TensorFlow libraries
-# If tensorflow is not installed, import interpreter from tflite_runtime, else import from regular tensorflow
+# If tflite_runtime is installed, import interpreter from tflite_runtime, else import from regular tensorflow
 # If using Coral Edge TPU, import the load_delegate library
-pkg = importlib.util.find_spec('tensorflow')
-if pkg is None:
+pkg = importlib.util.find_spec('tflite_runtime')
+if pkg:
     from tflite_runtime.interpreter import Interpreter
     if use_TPU:
         from tflite_runtime.interpreter import load_delegate

--- a/get_pi_requirements.sh
+++ b/get_pi_requirements.sh
@@ -7,12 +7,11 @@ sudo apt-get -y install libavcodec-dev libavformat-dev libswscale-dev libv4l-dev
 sudo apt-get -y install libxvidcore-dev libx264-dev
 sudo apt-get -y install qt4-dev-tools libatlas-base-dev
 
+# Need to get an older version of OpenCV because version 4 has errors
 pip3 install opencv-python==3.4.6.27
 
 # Get packages required for TensorFlow
-
-# For now, downloading the TensorFlow builds from lhelontra's "TensorFlow on ARM" repository
-# Thanks lhelontra for being super awesome!
+# Using the tflite_runtime packages available at https://www.tensorflow.org/lite/guide/python
 # Will change to just 'pip3 install tensorflow' once newer versions of TF are added to piwheels
 
 #pip3 install tensorflow
@@ -20,14 +19,10 @@ pip3 install opencv-python==3.4.6.27
 version=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
 
 if [ $version == "3.7" ]; then
-wget https://github.com/lhelontra/tensorflow-on-arm/releases/download/v2.0.0/tensorflow-2.0.0-cp37-none-linux_armv7l.whl
-pip3 install tensorflow-2.0.0-cp37-none-linux_armv7l.whl
-rm tensorflow-2.0.0-cp37-none-linux_armv7l.whl
+pip3 install https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp37-cp37m-linux_armv7l.whl
 fi
 
 if [ $version == "3.5" ]; then
-wget https://dl.google.com/coral/python/tflite_runtime-1.14.0-cp35-cp35m-linux_armv7l.whl
-pip3 install tflite_runtime-1.14.0-cp35-cp35m-linux_armv7l.whl
-rm tflite_runtime-1.14.0-cp35-cp35m-linux_armv7l.whl
+pip3 install https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp35-cp35m-linux_armv7l.whl
 fi
 


### PR DESCRIPTION
Updating get_pi_requirements.sh to install tflite_runtime v2.1 rather than tensorflow v2.0. Also changed tensorflow importing code to prioritize importing from tflite_runtime over importing from tensorflow.

I did this to resolve [this issue with the Coral USB Accelerator](https://github.com/EdjeElectronics/TensorFlow-Lite-Object-Detection-on-Android-and-Raspberry-Pi/issues/46). The latest version of libedgetpu does not work with TF v2.0, but works with TF v2.1. Regular TF v2.1 is not available on piwheels or PyPI yet, so I have people download tflite_runtime v2.1 instead. (I had intended to have people download tflite_runtime in the first place, but when I originally wrote the guide, tflite_runtime was not available for Python 3.7, which is what Raspbian Buster uses.)

So why make it so the code prioritizes importing from tflite_runtime over tensorflow? Consider this corner case: What if someone followed my [TFLite video](https://www.youtube.com/watch?v=aimSGOAUI8Y) and has tensorflow v2.0 installed, but then wants to follow my soon-to-be-posted video on setting up the Coral USB Accelerator? They'll run into [this error](https://github.com/EdjeElectronics/TensorFlow-Lite-Object-Detection-on-Android-and-Raspberry-Pi/issues/46)! To fix the error, now they can just install tflite_runtime v2.1 with no other changes. If I hadn't changed the priority, they would have had to uninstall tensorflow v2.0 too. Okay, it would have been pretty easy to just tell them to uninstall tensorflow v2.0 first and then install tflite_runtime v2.1, but whatever!