### PR TITLE
Added jpeg file list to train_val_test_split.py

### DIFF
--- a/util_scripts/train_val_test_split.py
+++ b/util_scripts/train_val_test_split.py
@@ -18,12 +18,13 @@ val_path = '/content/images/validation'
 test_path = '/content/images/test'
 
 # Get list of all images
+jpeg_file_list = [path for path in Path(image_path).rglob('*.jpeg')]
 jpg_file_list = [path for path in Path(image_path).rglob('*.jpg')]
 JPG_file_list = [path for path in Path(image_path).rglob('*.JPG')]
 png_file_list = [path for path in Path(image_path).rglob('*.png')]
 bmp_file_list = [path for path in Path(image_path).rglob('*.bmp')]
 
-file_list = jpg_file_list + JPG_file_list + png_file_list + bmp_file_list
+file_list = jpeg_file_list + jpg_file_list + JPG_file_list + png_file_list + bmp_file_list
 file_num = len(file_list)
 print('Total images: %d' % file_num)
 


### PR DESCRIPTION
train_val_test_split.py supported .jpg and .JPG file types, but not .jpeg so this PR adds support to .jpeg format.