### PR TITLE
Add macos deployment guide

### DIFF
--- a/deploy_guides/MacOS_TFLite_Guide.md
+++ b/deploy_guides/MacOS_TFLite_Guide.md
@@ -1,5 +1,5 @@
 # How to Run TensorFlow Lite Models on macOS
-This guide shows how to set up a TensorFlow Lite Runtime environment on a MacOS device. We'll use [Anaconda](https://www.anaconda.com/) to create a Python environment to install the TFLite Runtime in. It's easy!
+This guide shows how to set up a TensorFlow Lite Runtime environment on a macOS device. We'll use [Anaconda](https://www.anaconda.com/) to create a Python environment to install the TFLite Runtime in. It's easy!
 
 ## Step 1. Download and Install Anaconda
 First, install [Anaconda](https://www.anaconda.com/), which is a Python environment manager that greatly simplifies Python package management and deployment. Anaconda allows you to create Python virtual environments on your PC without interfering with existing installations of Python. Go to the [Anaconda Downloads page](https://www.anaconda.com/products/distribution) and click the Download button.

--- a/deploy_guides/MacOS_TFLite_Guide.md
+++ b/deploy_guides/MacOS_TFLite_Guide.md
@@ -11,7 +11,7 @@ First open up the terminal by opening a Finder window, and press 'Command + Shif
 
 ```
 mkdir ~/tflite1
-cd tflite1
+cd ~/tflite1
 ```
 
 Next, create a Python 3.9 virtual environment by issuing:

--- a/deploy_guides/MacOS_TFLite_Guide.md
+++ b/deploy_guides/MacOS_TFLite_Guide.md
@@ -10,7 +10,7 @@ When the download finishes, open the downloaded .exe file and step through the i
 First open up the terminal by opening a Finder window, and press 'Command + Shift + U', and then select Terminal. We'll create a folder called `tflite1` directly in the Home folder (under your username) - you can use any other folder location you like, just make sure to modify the commands below to use the correct file paths. Create the folder and move into it by issuing the following commands in the terminal:
 
 ```
-mkdir tflite1
+mkdir ~/tflite1
 cd tflite1
 ```
 

--- a/deploy_guides/MacOS_TFLite_Guide.md
+++ b/deploy_guides/MacOS_TFLite_Guide.md
@@ -40,7 +40,7 @@ curl https://raw.githubusercontent.com/EdjeElectronics/TensorFlow-Lite-Object-De
 ```
 
 ## Step 3. Move TFLite Model into Directory
-Next, take the custom TFLite model that was trained and downloaded from the Colab notebook and move it into the {username}\tflite1 directory (replacing {username} with your home directory name). If you downloaded it from Colab, it should be in a file called `custom_model_lite.zip`. (If you haven't trained a model yet and just want to test one out, download my "bird, squirrel, raccoon" model by clicking this Dropbox link.) Move that file to the {username}\tflite1 directory. Once it's moved, unzip it using:
+Next, take the custom TFLite model that was trained and downloaded from the Colab notebook and move it into the {username}\tflite1 directory (replacing {username} with your home directory name). If you downloaded it from Colab, it should be in a file called `custom_model_lite.zip`. (If you haven't trained a model yet and just want to test one out, download my "change counter" model by clicking this [Dropbox link](https://www.dropbox.com/scl/fi/4fk8ls8s03c94g6sb3ngo/custom_model_lite.zip?rlkey=zqda21sowk0hrw6i3f2dgbsyy&dl=0).) Move that file to the {username}\tflite1 directory. Once it's moved, unzip it using:
 
 ```
 tar -xf custom_model_lite.zip

--- a/deploy_guides/MacOS_TFLite_Guide.md
+++ b/deploy_guides/MacOS_TFLite_Guide.md
@@ -1,4 +1,4 @@
-# How to Run TensorFlow Lite Models on MacOS
+# How to Run TensorFlow Lite Models on macOS
 This guide shows how to set up a TensorFlow Lite Runtime environment on a MacOS device. We'll use [Anaconda](https://www.anaconda.com/) to create a Python environment to install the TFLite Runtime in. It's easy!
 
 ## Step 1. Download and Install Anaconda

--- a/deploy_guides/MacOS_TFLite_Guide.md
+++ b/deploy_guides/MacOS_TFLite_Guide.md
@@ -49,7 +49,7 @@ tar -xf custom_model_lite.zip
 At this point, you should have a folder at {username}\tflite1\custom_model_lite which contains at least a `detect.tflite` and `labelmap.txt` file.
 
 ## Step 4. Run TensorFlow Lite Model!
-Now just call one of the detection scripts and point it at your model folder with the `--modeldir` option. For example, to run your `custom_model_lite` model on a webcam, issue:
+Now, just call one of the detection scripts and point it at your model folder with the `--modeldir` option. For example, to run your `custom_model_lite` model on a webcam, issue:
 
 ```
 python TFLite_detection_webcam.py --modeldir=custom_model_lite

--- a/deploy_guides/MacOS_TFLite_Guide.md
+++ b/deploy_guides/MacOS_TFLite_Guide.md
@@ -2,7 +2,7 @@
 This guide shows how to set up a TensorFlow Lite Runtime environment on a macOS device. We'll use [Anaconda](https://www.anaconda.com/) to create a Python environment to install the TFLite Runtime in. It's easy!
 
 ## Step 1. Download and Install Anaconda
-First, install [Anaconda](https://www.anaconda.com/), which is a Python environment manager that greatly simplifies Python package management and deployment. Anaconda allows you to create Python virtual environments on your PC without interfering with existing installations of Python. Go to the [Anaconda Downloads page](https://www.anaconda.com/products/distribution) and click the Download button.
+First, install [Anaconda](https://www.anaconda.com/), which is a Python environment manager that greatly simplifies Python package management and deployment. Anaconda allows you to create Python virtual environments on your Mac without interfering with existing installations of Python. Go to the [Anaconda Downloads page](https://www.anaconda.com/products/distribution) and click the Download button.
 
 When the download finishes, open the downloaded .exe file and step through the installation wizard. Use the default install options.
 

--- a/deploy_guides/MacOS_TFLite_Guide.md
+++ b/deploy_guides/MacOS_TFLite_Guide.md
@@ -1,0 +1,60 @@
+# How to Run TensorFlow Lite Models on MacOS
+This guide shows how to set up a TensorFlow Lite Runtime environment on a MacOS device. We'll use [Anaconda](https://www.anaconda.com/) to create a Python environment to install the TFLite Runtime in. It's easy!
+
+## Step 1. Download and Install Anaconda
+First, install [Anaconda](https://www.anaconda.com/), which is a Python environment manager that greatly simplifies Python package management and deployment. Anaconda allows you to create Python virtual environments on your PC without interfering with existing installations of Python. Go to the [Anaconda Downloads page](https://www.anaconda.com/products/distribution) and click the Download button.
+
+When the download finishes, open the downloaded .exe file and step through the installation wizard. Use the default install options.
+
+## Step 2. Set Up Virtual Environment and Directory
+First open up the terminal by opening a Finder window, and press 'Command + Shift + U', and then select Terminal. We'll create a folder called `tflite1` directly in the Home folder (under your username) - you can use any other folder location you like, just make sure to modify the commands below to use the correct file paths. Create the folder and move into it by issuing the following commands in the terminal:
+
+```
+mkdir tflite1
+cd tflite1
+```
+
+Next, create a Python 3.9 virtual environment by issuing:
+
+```
+conda create --name tflite1-env python=3.9
+```
+
+Enter "y" then "ENTER" when it asks if you want to proceed. Activate the environment and install the required packages by issuing the commands below. We'll install TensorFlow, OpenCV, and a downgraded version of protobuf. TensorFlow is a pretty big download (about 450MB), so it will take a while.
+
+```
+conda activate tflite1-env
+pip install tensorflow
+pip install opencv-python
+pip uninstall protobuf
+pip install protobuf==3.20.0
+```
+
+Download the detection scripts from this repository by issuing:
+
+```
+curl https://raw.githubusercontent.com/EdjeElectronics/TensorFlow-Lite-Object-Detection-on-Android-and-Raspberry-Pi/master/TFLite_detection_image.py --output TFLite_detection_image.py
+curl https://raw.githubusercontent.com/EdjeElectronics/TensorFlow-Lite-Object-Detection-on-Android-and-Raspberry-Pi/master/TFLite_detection_video.py --output TFLite_detection_video.py
+curl https://raw.githubusercontent.com/EdjeElectronics/TensorFlow-Lite-Object-Detection-on-Android-and-Raspberry-Pi/master/TFLite_detection_webcam.py --output TFLite_detection_webcam.py
+curl https://raw.githubusercontent.com/EdjeElectronics/TensorFlow-Lite-Object-Detection-on-Android-and-Raspberry-Pi/master/TFLite_detection_stream.py --output TFLite_detection_stream.py
+```
+
+## Step 3. Move TFLite Model into Directory
+Next, take the custom TFLite model that was trained and downloaded from the Colab notebook and move it into the {username}\tflite1 directory (replacing {username} with your home directory name). If you downloaded it from Colab, it should be in a file called `custom_model_lite.zip`. (If you haven't trained a model yet and just want to test one out, download my "bird, squirrel, raccoon" model by clicking this Dropbox link.) Move that file to the {username}\tflite1 directory. Once it's moved, unzip it using:
+
+```
+tar -xf custom_model_lite.zip
+```
+
+At this point, you should have a folder at {username}\tflite1\custom_model_lite which contains at least a `detect.tflite` and `labelmap.txt` file.
+
+## Step 4. Run TensorFlow Lite Model!
+Now just call one of the detection scripts and point it at your model folder with the `--modeldir` option. For example, to run your `custom_model_lite` model on a webcam, issue:
+
+```
+python TFLite_detection_webcam.py --modeldir=custom_model_lite
+```
+
+A window will appear showing detection results drawn on the live webcam feed, make sure to accept the use of webcam. For more information on how to use the detection scripts, like if you want to enter an image, video, or web stream please see [Step 3 in the main README page](https://github.com/EdjeElectronics/TensorFlow-Lite-Object-Detection-on-Android-and-Raspberry-Pi#step-3-run-tensorflow-lite-models).
+
+Have fun using TensorFlow Lite! Stay tuned for more examples on how to build cool applications around your model.

--- a/deploy_guides/Windows_TFLite_Guide.md
+++ b/deploy_guides/Windows_TFLite_Guide.md
@@ -37,7 +37,7 @@ curl https://raw.githubusercontent.com/EdjeElectronics/TensorFlow-Lite-Object-De
 ```
 
 ## Step 3. Move TFLite Model into Directory
-Next, take the custom TFLite model that was trained and downloaded from the Colab notebook and move it into the C:\tflite1 directory. If you downloaded it from Colab, it should be in a file called `custom_model_lite.zip`. (If you haven't trained a model yet and just want to test one out, download my "bird, squirrel, raccoon" model by clicking this Dropbox link.) Move that file to the C:\tflite1 directory. Once it's moved, unzip it using:
+Next, take the custom TFLite model that was trained and downloaded from the Colab notebook and move it into the C:\tflite1 directory. If you downloaded it from Colab, it should be in a file called `custom_model_lite.zip`. (If you haven't trained a model yet and just want to test one out, download my "change counter" model by clicking this [Dropbox link](https://www.dropbox.com/scl/fi/4fk8ls8s03c94g6sb3ngo/custom_model_lite.zip?rlkey=zqda21sowk0hrw6i3f2dgbsyy&dl=0).) Move that file to the C:\tflite1 directory. Once it's moved, unzip it using:
 
 ```
 tar -xf custom_model_lite.zip


### PR DESCRIPTION
This pull request enables MacOS users to deploy the TFLite model. The guide provides step-by-step instructions for deploying a TensorFlow Lite object detection model on MacOS, enabling users to leverage the model efficiently for their applications.

Changes:

1. Added a new section to the project documentation titled "MacOS_TFLite_Guide.md".
2. Included detailed instructions on setting up the required dependencies on MacOS.
3. Provided step-by-step instructions for downloading and configuring Anaconda, using the same steps as the Windows guide.
4. Included commands to assist users in integrating the model into their MacOS applications.
5. Updated the main README to link to the new macOS deployment guide.

Purpose:

The addition of this deployment guide aims to make the project more accessible to macOS users who wish to utilise TensorFlow Lite object detection models in their applications. 

