### PR TITLE
Remove mAP outputs before run the script for quantized model

### DIFF
--- a/Train_TFLite2_Object_Detction_Model.ipynb
+++ b/Train_TFLite2_Object_Detction_Model.ipynb
@@ -1490,6 +1490,7 @@
       "source": [
         "# Need to remove existing detection results first\n",
         "!rm /content/mAP/input/detection-results/*\n",
+        "!rm -r /content/mAP/outputs\n",
         "\n",
         "# Set up variables for running inference, this time to get detection results saved as .txt files\n",
         "PATH_TO_IMAGES='/content/images/test'   # Path to test images folder\n",


### PR DESCRIPTION
Hello mantainers, the `calculate_map_cartucho.py` script doesn't work if already exist a `/content/mAP/outputs` file.
This change remove this output before running the script for the quantized model.